### PR TITLE
Fix Flow title styling

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -37,7 +37,7 @@ Online purchases. Web Monetization is intended to enable very small payments. Th
  - Users enroll with one or more **Web Monetization providers (WM provider)**, responsible for making payments to websites on the user's behalf. The WM provider has a software component registered with the user's browser (_a browser extension, service worker or some other component type, this aspect of the proposal is not yet well defined_).
  - Websites sign up with (or run their own) **Web Monetization Receiver (WM receiver)**, responsible for accepting payments from their user's WM providers (_e.g. a likely candidate to be a WM receiver would be a digital wallet_).
 
- ### Flow
+### Flow
 
 _This flow is simplified to exclude some edge cases. Numbers correspond to the diagram above._
 


### PR DESCRIPTION
I think this extra space is preventing the "Flow" title from rendering correctly?

This is how it currently shows up in: https://adrianhopebailie.github.io/web-monetization/explainer.html

![firefox_2019-08-17_18-59-42](https://user-images.githubusercontent.com/1711126/63218099-4491d400-c121-11e9-8e1f-ca27b50f2ed2.png)
