### PR TITLE
Remove confusing "may not"

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,8 +262,7 @@
                   The <a>user agent</a> also emits a
                   {{progress}} event from
                   <code>document.monetization</code>, corresponding to this
-                  first packet. If there are no listeners the event MAY NOT be
-                  emitted.
+                  first packet.
                 </li>
               </ul>
             </li>
@@ -288,8 +287,7 @@
                   {{MonetizationProgressEvent}}
                   on
                   <code>document.monetization</code>. The event has details of
-                  the packet. If there are no listeners the event MAY NOT be
-                  emitted.
+                  the packet.
                 </li>
                 <li>
                   When a stream is closed the


### PR DESCRIPTION
The purpose of the sentence in the original spec was just that the events don't need to be fired if no listeners exist. This isn't really useful and some people reading the spec have found it quite confusing. This PR just removes the offending sentences.